### PR TITLE
Move react to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "react": ">=15.0.0 || >= 16.0.0"
   },
   "dependencies": {
-    "hoist-non-react-statics": "^2.3.1",
-    "react": "^16.8.6"
+    "hoist-non-react-statics": "^2.3.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
@@ -59,6 +58,7 @@
     "jest-watch-typeahead": "^0.2.0",
     "lint-staged": "^7.3.0",
     "prettier": "^1.14.3",
+    "react": "^16.8.6",
     "react-dom": "^16.8.4",
     "react-testing-library": "^5.2.1",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
This keeps the `peerDependencies` honest and doesn't install a specific version of react.
The current behavior breaks apps with react >=17